### PR TITLE
Fix Terminal value in desktop file

### DIFF
--- a/gpu-viewer.desktop
+++ b/gpu-viewer.desktop
@@ -8,4 +8,4 @@ Exec=/usr/share/gpu-viewer/GPUViewer
 Icon=/usr/share/gpu-viewer/Images/GPU_Viewer.png
 Type=Application
 Categories=GTK;GNOME;System
-Terminal=False
+Terminal=false


### PR DESCRIPTION
As per the spec the values are `true` or `false`, case-sensitive.

https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#value-types