### PR TITLE
Remove deprecated Encoding key from desktop file

### DIFF
--- a/gpu-viewer.desktop
+++ b/gpu-viewer.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Type=Application
 Version=1.5
 Name=GPU-Viewer


### PR DESCRIPTION
See Appendix C. Deprecated Items @ https://specifications.freedesktop.org/desktop-entry-spec/latest/apc.html