### PR TITLE
Remove reference to yaourt and correct command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This project aims to capture all the important details of glxinfo, vulkaninfo an
     Please note all the dependencies python, vulkan-tools,clinfo, es2_info will be installed, if not installed before.
 
 4. **Debian based distro** users should be able to install the application by just running the .deb file attached in the Release notes
-5. **Arch based distro** - 	[![Packaging status](https://repology.org/badge/vertical-allrepos/gpu-viewer.svg)](https://repology.org/project/gpu-viewer/versions) - users should be able to grab the application at https://aur.archlinux.org/packages/gpu-viewer/ or by running command **yaourt -s gpu-viewer** from the terminal . This should automatically take care of the dependencies. Thanks to **Dan Johnson (strit)** for maintaining the AUR Package
+5. **Arch based distro** - 	[![Packaging status](https://repology.org/badge/vertical-allrepos/gpu-viewer.svg)](https://repology.org/project/gpu-viewer/versions) - users should be able to grab the application at https://aur.archlinux.org/packages/gpu-viewer/ or by running command **yay -S gpu-viewer** from the terminal . This should automatically take care of the dependencies. Thanks to **Dan Johnson (strit)** for maintaining the AUR Package
 6. **Fedora (RPM) based distro** run the command **sudo dnf -y install clinfo egl-utils mesa-demos mesa-vulkan-drivers python3 vdpauinfo vulkan-tools** from the terminal, then complete steps 7 to 10.
 7. For others please follow steps 7 to 10
 8. Download the file  and Extract to a folder


### PR DESCRIPTION
`yaourt` has fallen out of favor within the Arch Community, while there are more AUR helpers out there than I can count, I think most people use `yay`. My change to your readme should reflect that so it doesn't look like it hasn't been updated in 3+ years