### PR TITLE
Adding openSUSE's installation step.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,16 @@ This project aims to capture all the important details of glxinfo, vulkaninfo an
 
 4. **Debian based distro** users should be able to install the application by just running the .deb file attached in the Release notes
 5. **Arch based distro** - 	[![Packaging status](https://repology.org/badge/vertical-allrepos/gpu-viewer.svg)](https://repology.org/project/gpu-viewer/versions) - users should be able to grab the application at https://aur.archlinux.org/packages/gpu-viewer/ or by running command **yay -S gpu-viewer** from the terminal . This should automatically take care of the dependencies. Thanks to **Dan Johnson (strit)** for maintaining the AUR Package
-6. **Fedora (RPM) based distro** run the command **sudo dnf -y install clinfo egl-utils mesa-demos mesa-vulkan-drivers python3 vdpauinfo vulkan-tools** from the terminal, then complete steps 7 to 10.
-7. For others please follow steps 7 to 10
-8. Download the file  and Extract to a folder
-9. Navigate to extracted folder, open terminal and enter below commands
+6. **Fedora based distro** run the command **sudo dnf -y install clinfo egl-utils mesa-demos mesa-vulkan-drivers python3 vdpauinfo vulkan-tools** from the terminal, then complete steps 8 to 11.
+7. **openSUSE based distro** run the command **sudo zypper install clinfo mesa-demo mesa-demo-egl mesa-demo-es mesa-vulkan-device-select libvulkan_intel libvulkan_lvp libvulkan_radeon python3 libvdpau1 vulkan-tools** from the terminal, then complete steps 8 to 11.
+8. For others please follow steps 8 to 11
+9. Download the file  and Extract to a folder
+10. Navigate to extracted folder, open terminal and enter below commands
     - meson _build
     - cd _build
     - ninja install
-10. Once completed,Application can be accessed at menu->System/Administration/System tools->GPU Viewer
-11. For **Vulkan Tab** to work Install vulkan-tools (sudo apt-get install vulkan-tools) in Ubuntu, vulkan-tools in Arch, Vulkan in Solus, also Vulkan enabled drivers should be installed.
+11. Once completed,Application can be accessed at menu->System/Administration/System tools->GPU Viewer
+12. For **Vulkan Tab** to work Install vulkan-tools (sudo apt-get install vulkan-tools) in Ubuntu, vulkan-tools in Arch, Vulkan in Solus, also Vulkan enabled drivers should be installed.
 The installer should be able to take care of this dependency in Debian based distro and Solus.
 12. For **OpenCL Tab** to work install clinfo (sudo apt install clinfo) in ubuntu , clinfo in Solus (sudo eopkg install clinfo), clinfo in arch. Also, ensure you have OpenCL installed for your respective platforms, Ex. Nvidia CUDA for Nvidia hardware, beignet for Intel Graphics or pocpl for cpu or AMD openCL for AMD hardware.
 13. For **EGL** information to be displayed in OpenGL tab, users should install mesa-utils-extra package in Debian based systems. On Arch, Please install latest version of mesa-demos

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This project aims to capture all the important details of glxinfo, vulkaninfo an
 4. **Debian based distro** users should be able to install the application by just running the .deb file attached in the Release notes
 5. **Arch based distro** - 	[![Packaging status](https://repology.org/badge/vertical-allrepos/gpu-viewer.svg)](https://repology.org/project/gpu-viewer/versions) - users should be able to grab the application at https://aur.archlinux.org/packages/gpu-viewer/ or by running command **yay -S gpu-viewer** from the terminal . This should automatically take care of the dependencies. Thanks to **Dan Johnson (strit)** for maintaining the AUR Package
 6. **Fedora based distro** run the command **sudo dnf -y install clinfo egl-utils mesa-demos mesa-vulkan-drivers python3 vdpauinfo vulkan-tools** from the terminal, then complete steps 8 to 11.
-7. **openSUSE based distro** run the command **sudo zypper install clinfo mesa-demo mesa-demo-egl mesa-demo-es mesa-vulkan-device-select libvulkan_intel libvulkan_lvp libvulkan_radeon python3 libvdpau1 vulkan-tools** from the terminal, then complete steps 8 to 11.
+7. **openSUSE based distro** run the command **sudo zypper install clinfo mesa-demo mesa-vulkan-device-select libvulkan_intel libvulkan_lvp libvulkan_radeon python3 libvdpau1 vulkan-tools** from the terminal, then complete steps 8 to 11.
 8. For others please follow steps 8 to 11
 9. Download the file  and Extract to a folder
 10. Navigate to extracted folder, open terminal and enter below commands


### PR DESCRIPTION
openSUSE required packages are a bit different from Fedora as the followings:

- **[egl-utils](https://fedora.pkgs.org/36/fedora-x86_64/egl-utils-8.4.0-13.20210504git0f9e7d9.fc36.x86_64.rpm.html)** package that provides _eglinfo_ and _es2_info_, would be in the package **mesa-demo-egl** and **mesa-demo-es** that are part of the **[mesa-demo](https://opensuse.pkgs.org/tumbleweed/opensuse-oss-x86_64/Mesa-demo-8.5.0-1.1.x86_64.rpm.html)** package on openSUSE.
- **[mesa-demos](https://fedora.pkgs.org/36/fedora-x86_64/mesa-demos-8.4.0-13.20210504git0f9e7d9.fc36.x86_64.rpm.html)** is **[mesa-demo](https://opensuse.pkgs.org/tumbleweed/opensuse-oss-x86_64/Mesa-demo-8.5.0-1.1.x86_64.rpm.html)** on openSUSE.
- **[mesa-vulkan-drivers](https://fedora.pkgs.org/36/fedora-x86_64/mesa-vulkan-drivers-22.0.1-1.fc36.x86_64.rpm.html)** that provides _libVkLayer_MESA_device_select_, _libvulkan_intel_, _libvulkan_lvp_, _libvulkan_radeon_, can be installed separately as **mesa-vulkan-device-select**, **libvulkan_intel**, **libvulkan_lvp**, and **libvulkan_radeon** packages on openSUSE.
- **[vdpauinfo](https://fedora.pkgs.org/36/fedora-x86_64/vdpauinfo-1.4-2.fc36.x86_64.rpm.html)** is part of **[libvdpau1](https://opensuse.pkgs.org/tumbleweed/opensuse-oss-x86_64/libvdpau1-1.5-1.3.x86_64.rpm.html)** on openSUSE.

Therefore, on openSUSE, the user needs to install required packages with:
```
sudo zypper install clinfo mesa-demo mesa-vulkan-device-select libvulkan_intel libvulkan_lvp libvulkan_radeon python3 libvdpau1 vulkan-tools
```