### PR TITLE
MetaInfo: Add missing releases

### DIFF
--- a/data/io.github.arunsivaramanneo.GPUViewer.metainfo.xml
+++ b/data/io.github.arunsivaramanneo.GPUViewer.metainfo.xml
@@ -30,6 +30,13 @@
     </screenshots>
     <content_rating type="oars-1.1"/>
     <releases>
+        <release version="2.20" date="2023-01-24"/>
+        <release version="2.15" date="2023-01-21"/>
+        <release version="2.13" date="2023-01-13"/>
+        <release version="2.12" date="2023-01-06"/>
+        <release version="2.02" date="2022-12-23"/>
+        <release version="1.43" date="2022-11-05"/>
+        <release version="1.42" date="2022-07-05"/>
         <release version="1.40" date="2022-04-28"/>
         <release version="1.38" date="2022-03-21"/>
         <release version="1.37" date="2021-12-06"/>


### PR DESCRIPTION
We need this at least for Flathub in order to display the application's version correctly.  
I would appreciate if the file would be updated when a new release is tagged.