### PR TITLE
Install tab icons into application-specific path

### DIFF
--- a/Files/GPUViewer.py
+++ b/Files/GPUViewer.py
@@ -91,6 +91,9 @@ else:
         dark_action.connect("activate", on_dark_action_actived,win)
         win.add_action(dark_action) # (self window) == win in MENU_XML
 
+        icon_theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
+        icon_theme.add_search_path(os.path.abspath("../icons"))
+
         menubutton = Gtk.MenuButton.new()
         menubutton.set_icon_name("open-menu-symbolic") 
         menu = Gtk.Builder.new_from_string(const.MENU_XML, -1).get_object("app-menu")

--- a/data/meson.build
+++ b/data/meson.build
@@ -6,18 +6,18 @@ install_data('../Images/GPU_Viewer.png',
   rename: '@0@.png'.format(APPLICATION_ID),
   install_dir: get_option('datadir') / 'icons/hicolor/512x512/apps')
 install_data('../Images/Vulkan.png',
-  install_dir: get_option('datadir') / 'icons/hicolor/512x512/apps')
+  install_dir: get_option('datadir') / 'gpu-viewer/icons/hicolor/512x512/actions')
 install_data('../Images/OpenGL.png',
-  install_dir: get_option('datadir') / 'icons/hicolor/512x512/apps')
+  install_dir: get_option('datadir') / 'gpu-viewer/icons/hicolor/512x512/actions')
 install_data('../Images/Egl_logo.png',
-  install_dir: get_option('datadir') / 'icons/hicolor/512x512/apps')
+  install_dir: get_option('datadir') / 'gpu-viewer/icons/hicolor/512x512/actions')
 install_data('../Images/OpenGL_ES.png',
-  install_dir: get_option('datadir') / 'icons/hicolor/512x512/apps')
+  install_dir: get_option('datadir') / 'gpu-viewer/icons/hicolor/512x512/actions')
 install_data('../Images/OpenCL.png',
-  install_dir: get_option('datadir') / 'icons/hicolor/512x512/apps')
+  install_dir: get_option('datadir') / 'gpu-viewer/icons/hicolor/512x512/actions')
 install_data('../Images/about-us.png',
-  install_dir: get_option('datadir') / 'icons/hicolor/512x512/apps')
+  install_dir: get_option('datadir') / 'gpu-viewer/icons/hicolor/512x512/actions')
 install_data('../Images/vdpauinfo.png',
-  install_dir: get_option('datadir') / 'icons/hicolor/512x512/apps')
+  install_dir: get_option('datadir') / 'gpu-viewer/icons/hicolor/512x512/actions')
 install_data('../Images/settings.png',  
-  install_dir: get_option('datadir') / 'icons/hicolor/512x512/apps')
+  install_dir: get_option('datadir') / 'gpu-viewer/icons/hicolor/512x512/actions')


### PR DESCRIPTION
The tab icons are not application-namespaced and are only used within the application itself.  Since the names are very generic (e.g. `about-us`, `settings`), these should not be installed into the system icon theme.