### PR TITLE
Replace image links with img tags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@
 
 This project aims to capture all the important details of glxinfo, vulkaninfo and clinfo in a GUI. The project is being developed using python 3 pygobject with GTK4. All the important details are extracted using glxinfo/vulkaninfo/clinfo with the combination of grep, CAT , AWK commands and displayed in the front-end. There is no hard OpenGL Programming involved, until glxinfo, vulkaninfo and clinfo works the GPU-viewer will also work
 
-![Image](https://github.com/user-attachments/assets/591d9871-7689-4d42-a67e-219a084c9447)
+<img width="1734" height="1346" alt="Image" src="https://github.com/user-attachments/assets/900cbd5e-c188-4ce6-89c1-1b7b0ee73537" />
 
-![Image](https://github.com/user-attachments/assets/1ec150ec-dced-4f2d-93b4-cda4587706e3)
+<img width="1734" height="1346" alt="Image" src="https://github.com/user-attachments/assets/3a835a34-f782-49da-9382-4c4784b572d4" />
 
-![Image](https://github.com/user-attachments/assets/2aae31b8-30ce-4c32-a709-f09068baf08d)
+<img width="1734" height="1346" alt="Image" src="https://github.com/user-attachments/assets/d62c26c2-e95f-4244-891b-676b2dd95413" />
 
-![Image](https://github.com/user-attachments/assets/03f3c4ff-767b-4b71-a212-28eb72003508)
+<img width="1734" height="1346" alt="Image" src="https://github.com/user-attachments/assets/aba7723c-a2d5-46fd-baa4-6b9d9075721f" />
 
-![Image](https://github.com/user-attachments/assets/e5b5cfbf-cd04-46f8-8f4f-005d596c2f9f)
+<img width="1734" height="1346" alt="Image" src="https://github.com/user-attachments/assets/c7d9e577-fe92-42b8-8ad6-00033ce2c291" />
 
-![Image](https://github.com/user-attachments/assets/55dc9395-7891-4190-bc04-44c936388b0b)
+![opengl hardware limits_007](https://user-images.githubusercontent.com/3064692/31833704-134bc328-b5e9-11e7-95fc-6bcf7ea39d07.png)
 
 
 ## INSTALLATION STEPS


### PR DESCRIPTION
Updated image references in README.md to use img tags with specified dimensions.