### PR TITLE
fix filename for openCL image in meson.build

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -13,7 +13,7 @@ install_data('../Images/Egl_logo.png',
   install_dir: get_option('datadir') / 'gpu-viewer/icons/hicolor/512x512/actions')
 install_data('../Images/OpenGL_ES.png',
   install_dir: get_option('datadir') / 'gpu-viewer/icons/hicolor/512x512/actions')
-install_data('../Images/OpenCL.png',
+install_data('../Images/OpenCL.svg',
   install_dir: get_option('datadir') / 'gpu-viewer/icons/hicolor/512x512/actions')
 install_data('../Images/about-us.png',
   install_dir: get_option('datadir') / 'gpu-viewer/icons/hicolor/512x512/actions')


### PR DESCRIPTION
The filename for openCL image was wrong in meson.build.

Found this while trying to build v3.25.

So fix it in data/meson.build.