### PR TITLE
fix data/meson.build by changing the path to OpenCL's icon

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -13,7 +13,7 @@ install_data('../Images/Egl_logo.png',
   install_dir: get_option('datadir') / 'gpu-viewer/icons/hicolor/512x512/actions')
 install_data('../Images/OpenGL_ES.png',
   install_dir: get_option('datadir') / 'gpu-viewer/icons/hicolor/512x512/actions')
-install_data('../Images/OpenCL.png',
+install_data('../Images/OpenCL.svg',
   install_dir: get_option('datadir') / 'gpu-viewer/icons/hicolor/512x512/actions')
 install_data('../Images/about-us.png',
   install_dir: get_option('datadir') / 'gpu-viewer/icons/hicolor/512x512/actions')


### PR DESCRIPTION
Currently fails with
`gpu-viewer` is failing to build since https://github.com/arunsivaramanneo/GPU-Viewer/commit/a0968c5a452d27cbec7b9194b6a442ae7301812d with:
```
data/meson.build:16:0: ERROR: File ../Images/OpenCL.png does not exist.
```

This patch fixes the path to the OpenCL logo (`.png` -> `.svg`).

Context: https://github.com/NixOS/nixpkgs/pull/488804
