### PR TITLE
[readme] correct Arch Linux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Dark theme
     Please note all the dependencies python, vulkan-tools,clinfo, es2_info will be installed, if not installed before.
 
 4. **Debian based distro** users should be able to install the application by just running the .deb file attached in the Release notes
-5. **Arch based distro**  - users should be able to grab the application at https://aur.archlinux.org/packages/gpu-viewer/ or by running command **yay -S gpu-viewer** from the terminal . This should automatically take care of the dependencies. Thanks to **Dan Johnson (strit)** for maintaining the AUR Package
+5. **Arch based distro**  - users can install the package with **sudo pacman -S gpu-viewer**.
 6. **Fedora based distro** run the command **sudo dnf -y install clinfo egl-utils mesa-demos mesa-vulkan-drivers python3 vdpauinfo vulkan-tools** from the terminal, then complete steps 8 to 11.
 7. **openSUSE based distro** run the command **sudo zypper install clinfo mesa-demo mesa-vulkan-device-select libvulkan_intel libvulkan_lvp libvulkan_radeon python3 libvdpau1 vulkan-tools xdpyinfo xev xlsatoms xlsclients xlsfonts xprop xvinfo xwininfo** from the terminal, then complete steps 8 to 11.
 8. For others please follow steps 8 to 11


### PR DESCRIPTION
gpu-viewer is now part of the [extra] repo in Arch Linux and has been removed from the AUR.

So correct the installation instructions for Arch Linux distros.

Thanks for developing this software.